### PR TITLE
added capistrano deploy script

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,4 @@
+load 'deploy'
+# Uncomment if you are using Rails' asset pipeline
+load 'deploy/assets'
+load 'config/deploy' # remove this line to skip loading any of the default tasks

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://ruby.taobao.org'
+source 'http://rubygems.org'
 
 gem 'rails', '~> 3.2.2'
 gem 'mailhopper'
@@ -12,6 +12,8 @@ gem 'rails_kindeditor', '~> 0.3.8'
 gem 'dynamic_form'
 gem "galetahub-simple_captcha", :require => "simple_captcha"
 gem "rmagick"
+gem 'capistrano'
+gem 'rvm-capistrano'
 # CanCan can not work perfectly with strong_parameters, will use slice pattern.
 # TODO: Use strong_parameters when CanCan fix this issue.
 #gem "strong_parameters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://ruby.taobao.org/
+  remote: http://rubygems.org/
   specs:
     actionmailer (3.2.12)
       actionpack (= 3.2.12)
@@ -40,6 +40,12 @@ GEM
       mocha (= 0.10.5)
     builder (3.0.4)
     cancan (1.6.9)
+    capistrano (2.14.2)
+      highline
+      net-scp (>= 1.0.0)
+      net-sftp (>= 2.0.0)
+      net-ssh (>= 2.0.14)
+      net-ssh-gateway (>= 1.1.0)
     capybara (2.0.2)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -154,6 +160,13 @@ GEM
     multi_json (1.6.0)
     multi_xml (0.5.3)
     mysql2 (0.3.11)
+    net-scp (1.1.0)
+      net-ssh (>= 2.6.5)
+    net-sftp (2.1.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.6.6)
+    net-ssh-gateway (1.2.0)
+      net-ssh (>= 2.6.5)
     nokogiri (1.5.6)
     orm_adapter (0.4.0)
     paperclip (3.4.0)
@@ -219,6 +232,8 @@ GEM
     ruby-prof (0.12.2)
     ruby-progressbar (1.0.2)
     rubyzip (0.9.9)
+    rvm-capistrano (1.2.7)
+      capistrano (>= 2.0.0)
     sass (3.2.5)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
@@ -274,6 +289,7 @@ DEPENDENCIES
   angular-rails (~> 0.0.12)
   annotate (~> 2.5.0)
   cancan
+  capistrano
   capybara
   capybara-webkit
   carrierwave
@@ -307,6 +323,7 @@ DEPENDENCIES
   rmagick
   rspec-rails (~> 2.12.0)
   ruby-prof
+  rvm-capistrano
   sass-rails (~> 3.2.3)
   shoulda-matchers (~> 1.4.2)
   simplecov

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@ require 'bundler/capistrano'
 require "rvm/capistrano"
 
 # Development server info
-set :rvm_ruby_string, 'ruby-1.9.3-p286@global'
+# set :rvm_ruby_string, 'ruby-1.9.3-p286@global'
 set :rvm_type, :system
 set :application, "newclass.org"
 set :scm, :git

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,62 @@
+require 'bundler/capistrano'
+require "rvm/capistrano"
+
+# Development server info
+set :rvm_ruby_string, 'ruby-1.9.3-p286@global'
+set :rvm_type, :system
+set :application, "newclass.org"
+set :scm, :git
+set :repository,  "git@github.com:jexchan/re-education.git"
+set :branch, 'master'
+set :user, "root"
+set :group, "root"
+set :deploy_via, :remote_cache
+set :keep_release, 3
+
+default_run_options[:pty] = true
+ssh_options[:forward_agent] = true
+
+server application, :app, :web, :db, :primary => true
+
+# Deploy to multiple environments
+desc "Run on staging server" 
+task :staging do 
+  set :deploy_to, "/var/www/#{application}/staging"
+end 
+ 
+desc "Run on production server" 
+task :production do 
+  set :deploy_to, "/var/www/#{application}/production"
+end 
+
+namespace :deploy do
+  task :start do ; end
+  task :stop do ; end
+  task :restart, :roles => :app, :except => { :no_release => true } do
+    run "touch #{File.join(current_path,'tmp','restart.txt')}"
+    run "nginx -s reload"
+  end
+
+  desc "Make symlink for database yaml"
+  task :db_symlink do
+    run "ln -nfs #{shared_path}/config/database.yml #{latest_release}/config/database.yml"
+  end
+
+  desc "Make symlink for uploaded files"
+  task :uploader_symlink do
+    run "rm -rf #{latest_release}/public/uploads"
+    run "ln -nfs #{shared_path}/public/uploads #{latest_release}/public/"
+  end 
+end
+
+before "deploy:assets:precompile", 
+       "deploy:db_symlink"
+
+after "bundle:install", 
+      "deploy:uploader_symlink"
+
+desc "Backup SQL"
+task :backup do 
+  run "cd /root/sqlbackup" 
+  run "backup perform --trigger newclass_backup -d . -c /root/sqlbackup/config.rb"
+end 


### PR DESCRIPTION
- Added capistrano deploy script
- Using http://rubygems.org rather than http://ruby.taobao.org as sometime retrieving will fail

Now, you can using `cap staging deploy` to deploy latest codes to staging(testing) environment, using `cap production deploy` to deploy codes to production (please don't do this before get permission)
